### PR TITLE
add autoredirect support

### DIFF
--- a/lib/ipgeobase.rb
+++ b/lib/ipgeobase.rb
@@ -1,5 +1,5 @@
 require 'uri'
-require 'net/http'
+require 'open-uri'
 
 module Ipgeobase
   URL = 'http://ipgeobase.ru:7020/geo'
@@ -8,7 +8,7 @@ module Ipgeobase
   def self.lookup(ip)
     uri = URI.parse(URL)
     uri.query = URI.encode_www_form :ip => ip
-
-    IpMetaData.parse(Net::HTTP.get(uri))
+    resp = open(uri).read()
+    IpMetaData.parse(resp.to_s)
   end
 end


### PR DESCRIPTION
Fixes issue #10

Example:

```
2.0.0-p247 :013 > a = Ipgeobase.lookup "46.8.114.116"
Fatal error: Space required after the Public Identifier at :1.
Fatal error: SystemLiteral " or ' expected at :1.
Fatal error: SYSTEM or PUBLIC, the URI is missing at :1.
LibXML::XML::Error: Fatal error: SYSTEM or PUBLIC, the URI is missing at :1.
    from /home/vagrant/.rvm/gems/ruby-2.0.0-p247/gems/happymapper-0.4.1/lib/happymapper.rb:91:in `parse'
    from /home/vagrant/.rvm/gems/ruby-2.0.0-p247/gems/happymapper-0.4.1/lib/happymapper.rb:91:in `parse'
from /home/vagrant/.rvm/gems/ruby-2.0.0-p247/gems/ipgeobase-0.1.0/lib/ipgeobase.rb:12:in `lookup'
from (irb):13
from /home/vagrant/.rvm/rubies/ruby-2.0.0-p247/bin/irb:16:in `<main>' 

2.0.0-p247 :014 > a = Ipgeobase.lookup "46.8.114.116"
 => #<Ipgeobase::IpMetaData:0x000000027f3dc8 @inetnum="46.8.112.0 - 46.8.127.255", @city="Ульяновск", @country="RU", @region="Ульяновская область", @district="Приволжский федеральный округ", @lat=54.32148, @lng=48.385651>
```

This was due to wrong response from server. It's try redirect you.
