### PR TITLE
Fix bug when trying to retrieve city when error response occured

### DIFF
--- a/lib/ipgeobase/ip_meta_data.rb
+++ b/lib/ipgeobase/ip_meta_data.rb
@@ -28,11 +28,13 @@ module Ipgeobase
 
     private
 
-    def encode(api_string)
-      if api_string.respond_to?(:encode)
-        api_string.encode("UTF-8")
+    def encode(entity)
+      return nil if entity.nil?
+
+      if entity.respond_to?(:encode)
+        entity.encode("UTF-8")
       else
-        Iconv.iconv('utf-8', 'windows-1251', api_string).first
+        Iconv.iconv('utf-8', 'windows-1251', entity).first
       end
     end
   end

--- a/test/lib/ip_meta_data_test.rb
+++ b/test/lib/ip_meta_data_test.rb
@@ -1,0 +1,11 @@
+# encoding: utf-8
+
+require 'test_helper'
+
+class IpMetaDataTest < TestCase
+  def test_should_work_with_incorrect_response
+    resp =  %Q{<?xml version="1.0" encoding="windows-1251"?><ip-answer><ip value="127.0.0.1"><message>Not found</message></ip></ip-answer>}
+    meta = Ipgeobase::IpMetaData.parse(resp)
+    assert_equal nil, meta.city
+  end
+end


### PR DESCRIPTION
I recently fixed a following error:

```
> Ipgeobase.lookup('127.0.0.1').city
NameError: uninitialized constant Ipgeobase::IpMetaData::Iconv
```

This error occurs when we get a 'not found' response from a web service:

```
<?xml version="1.0" encoding="windows-1251"?>
<ip-answer>
<ip value="127.0.0.1"><message>Not found</message></ip>
</ip-answer>
```

Please bump gem version after applying this PR.